### PR TITLE
Added monitor to check if Spotify is running/playing music.

### DIFF
--- a/SpotifyVolumeExtension/MediaKeyListener.cs
+++ b/SpotifyVolumeExtension/MediaKeyListener.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Windows.Forms;
 using Open.WinKeyboardHook;
 
@@ -6,23 +7,35 @@ namespace SpotifyVolumeExtension
 {
     public class MediaKeyListener
     {
-        private event Action<MediaKeyEventArgs> MediaKeyPressed;
+        public event Action<MediaKeyEventArgs> MediaKeyPressed;
         private MediaKeyEventArgs eventArgs;
-        private KeyboardInterceptor key;
+        public KeyboardInterceptor key;
         private int presses = 0;
+        private Thread mklThread;
 
-        public MediaKeyListener(Action<MediaKeyEventArgs> mediaKeyPressed)
+        public MediaKeyListener()
         {
             key = new KeyboardInterceptor();
             key.KeyDown += key_KeyDown;
             key.KeyUp += key_KeyUp;
-            MediaKeyPressed = mediaKeyPressed;
         }
 
         public void Start()
         {
-            key.StartCapturing();
-            Console.WriteLine("[MediaKeyListener] Started.");
+            mklThread = new Thread(() =>
+            {
+                key.StartCapturing();
+                Console.WriteLine("[MediaKeyListener] Started.");
+                Application.Run();
+            });
+            mklThread.Start();
+        }
+
+        public void Stop()
+        {
+            mklThread.Abort();
+            key.StopCapturing();
+            Console.WriteLine("[MediaKeyListener] Stopped.");
         }
 
         private void key_KeyUp(object sender, KeyEventArgs e)

--- a/SpotifyVolumeExtension/Program.cs
+++ b/SpotifyVolumeExtension/Program.cs
@@ -1,18 +1,22 @@
 ﻿using System.Windows.Forms;
 using SpotifyAPI.Web;
+
 namespace SpotifyVolumeExtension
 {
     class Program
     {
         static void Main(string[] args)
         {
-            VolumeGuard vg = new VolumeGuard();
-            vg.Start();
             SpotifyClient sc = new SpotifyClient(AuthType.Implicit);
             sc.Start();
+
+            VolumeGuard vg = new VolumeGuard(sc);
+            vg.Start();
+
             SpotifyVolumeController svc = new SpotifyVolumeController(sc);
             svc.Start();
-            Application.Run();
+
+            SpotifyMonitor.GetMonitorInstance(sc).Start();
         }
     }
 }

--- a/SpotifyVolumeExtension/Program.cs
+++ b/SpotifyVolumeExtension/Program.cs
@@ -1,5 +1,4 @@
-﻿using System.Windows.Forms;
-using SpotifyAPI.Web;
+﻿using SpotifyAPI.Web;
 
 namespace SpotifyVolumeExtension
 {
@@ -8,15 +7,14 @@ namespace SpotifyVolumeExtension
         static void Main(string[] args)
         {
             SpotifyClient sc = new SpotifyClient(AuthType.Implicit);
-            sc.Start();
-
-            VolumeGuard vg = new VolumeGuard(sc);
-            vg.Start();
-
+            SpotifyMonitor sm = SpotifyMonitor.GetMonitorInstance(sc);
+            VolumeGuard vg = new VolumeGuard();
             SpotifyVolumeController svc = new SpotifyVolumeController(sc);
-            svc.Start();
 
-            SpotifyMonitor.GetMonitorInstance(sc).Start();
+            sc.Start(sm);
+            vg.Start(sm);
+            svc.Start(sm);
+            sm.Start();
         }
     }
 }

--- a/SpotifyVolumeExtension/SpotifyClient.cs
+++ b/SpotifyVolumeExtension/SpotifyClient.cs
@@ -18,9 +18,9 @@ namespace SpotifyVolumeExtension
         private string _clientSecret = null; //Your Client-Secret here
         private AuthType authType;
 
-        public bool AnyDeviceIsActive
+        public bool MusicIsPlaying
         {
-            get => Api.GetDevices().Devices?.Any(x => x.IsActive) ?? false;
+            get => GetPlaybackContext().IsPlaying;
         }
         
         public SpotifyClient(AuthType authType) //AuthType.Authorization requires your own Client-ID and Client-Secret to work.

--- a/SpotifyVolumeExtension/SpotifyClient.cs
+++ b/SpotifyVolumeExtension/SpotifyClient.cs
@@ -4,7 +4,6 @@ using SpotifyAPI.Web.Auth;
 using SpotifyAPI.Web.Enums;
 using SpotifyAPI.Web.Models;
 using System.Threading;
-using System.Linq;
 
 namespace SpotifyVolumeExtension
 {

--- a/SpotifyVolumeExtension/SpotifyClient.cs
+++ b/SpotifyVolumeExtension/SpotifyClient.cs
@@ -37,10 +37,10 @@ namespace SpotifyVolumeExtension
             Api.UseAuth = true;
         }
 
-        public void Start()
+        public void Start(SpotifyMonitor sm)
         {
             Console.Write("[Spotify] Waiting for Spotify to start");
-            while (!SpotifyMonitor.GetMonitorInstance(this).GetPlayingStatus())
+            while (!sm.GetPlayingStatus())
             {
                 Console.Write(".");
                 Thread.Sleep(3000);

--- a/SpotifyVolumeExtension/SpotifyMonitor.cs
+++ b/SpotifyVolumeExtension/SpotifyMonitor.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Linq;
+using System.Diagnostics;
+using System.Threading;
+using System.Collections.Concurrent;
+
+namespace SpotifyVolumeExtension
+{
+    public class SpotifyMonitor : IObservable<SpotifyStatusChanged>
+    {
+        private SpotifyClient sc;
+        private bool lastSpotifyStatus;
+        private bool started;
+        private ConcurrentBag<IObserver<SpotifyStatusChanged>> observers;
+        private static object m = new object();
+
+        private static SpotifyMonitor sm;
+
+        SpotifyMonitor(SpotifyClient sc)
+        {
+            this.sc = sc;
+            observers = new ConcurrentBag<IObserver<SpotifyStatusChanged>>();
+        }
+
+        public static SpotifyMonitor GetMonitorInstance(SpotifyClient sc)
+        {
+            lock (m)
+            {
+                if (sm == null) sm = new SpotifyMonitor(sc);
+                return sm;
+            }
+        }
+
+        public void Start()
+        {
+            if (started) return;
+            Console.WriteLine("[SpotifyMonitor] Started. Now monitoring activity.");
+            started = true;
+            new Thread(() =>
+            {
+                while (true)
+                {
+                    if (GetPlayingStatus() != lastSpotifyStatus)
+                    {
+                        lastSpotifyStatus = !lastSpotifyStatus;
+                        foreach(var observer in observers)
+                        {
+                            observer.OnNext(new SpotifyStatusChanged(lastSpotifyStatus));
+                        }
+                    }
+                    Thread.Sleep(15000);
+                }
+            }).Start();
+        }
+
+        public bool GetPlayingStatus()
+        {
+            return SpotifyIsRunning() && IsPlayingMusic();
+        }
+
+        private bool SpotifyIsRunning()
+        {
+            var spotifyProcesses = Process.GetProcessesByName("Spotify");
+            return spotifyProcesses.Any();
+        }
+
+        private bool IsPlayingMusic()
+        {
+            return sc.AnyDeviceIsActive;
+        }
+
+        //IObservable<SpotifyStatusChanged> stuff below
+        public IDisposable Subscribe(IObserver<SpotifyStatusChanged> observer)
+        {
+            if (!observers.Contains(observer))
+                observers.Add(observer);
+            return new Unsubscriber(observers, observer);
+        }
+
+        private class Unsubscriber : IDisposable
+        {
+            private ConcurrentBag<IObserver<SpotifyStatusChanged>> _observers;
+            private IObserver<SpotifyStatusChanged> _observer;
+
+            public Unsubscriber(ConcurrentBag<IObserver<SpotifyStatusChanged>> observers, IObserver<SpotifyStatusChanged> observer)
+            {
+                this._observers = observers;
+                this._observer = observer;
+            }
+
+            public void Dispose()
+            {
+                if (_observer != null && _observers.Contains(_observer))
+                {
+                    _observer.OnCompleted();
+                    _observers.TryTake(out _observer);
+                }
+            }
+        }
+    }
+
+    public struct SpotifyStatusChanged
+    {
+        public SpotifyStatusChanged(bool status)
+        {
+            Status = status;
+        }
+        public bool Status { get; }
+    }
+
+}

--- a/SpotifyVolumeExtension/SpotifyMonitor.cs
+++ b/SpotifyVolumeExtension/SpotifyMonitor.cs
@@ -60,7 +60,7 @@ namespace SpotifyVolumeExtension
 
         private bool IsPlayingMusic()
         {
-            return sc.AnyDeviceIsActive;
+            return sc.MusicIsPlaying;
         }
     }
 }

--- a/SpotifyVolumeExtension/SpotifyVolumeController.cs
+++ b/SpotifyVolumeExtension/SpotifyVolumeController.cs
@@ -4,7 +4,7 @@ using System.Timers;
 
 namespace SpotifyVolumeExtension
 {
-    public class SpotifyVolumeController : IObserver<SpotifyStatusChanged>
+    public class SpotifyVolumeController
     {
         private MediaKeyListener mkl;
         private SpotifyClient sc;
@@ -30,7 +30,21 @@ namespace SpotifyVolumeExtension
         public void Start(SpotifyMonitor sm)
         {
             spotifyVolume = GetCurrentVolume(); //Get initial spotify-volume
-            sm.Subscribe(this);
+            sm.SpotifyStatusChanged += ToggleVolumeController;
+        }
+
+        private void ToggleVolumeController(bool status)
+        {
+            if (status)
+            {
+                mkl.Start();
+                spotifyVolume = GetCurrentVolume();
+            }
+            else
+            {
+                mkl.Stop();
+            }
+            Console.WriteLine("[SpotifyVolumeController] " + (status ? "Started." : "Stopped."));
         }
 
         private void UpdateVolume()
@@ -101,30 +115,6 @@ namespace SpotifyVolumeExtension
             {
                 Console.WriteLine($"[SpotifyVolumeController] Changed volume to {spotifyVolume}%");
             }
-        }
-
-        public void OnNext(SpotifyStatusChanged value)
-        {
-            if (value.Status)
-            {
-                mkl.Start();
-                spotifyVolume = GetCurrentVolume();
-            }
-            else
-            {
-                mkl.Stop();
-            }
-            Console.WriteLine("[SpotifyVolumeController] " + (value.Status ? "Started." : "Stopped."));
-        }
-
-        public void OnError(Exception error)
-        {
-            Console.WriteLine(error.StackTrace);
-        }
-
-        public void OnCompleted()
-        {
-            Console.WriteLine("[VolumeGuard] Stopped.");
         }
     }
 }

--- a/SpotifyVolumeExtension/SpotifyVolumeController.cs
+++ b/SpotifyVolumeExtension/SpotifyVolumeController.cs
@@ -27,10 +27,10 @@ namespace SpotifyVolumeExtension
             blockTimer.AutoReset = false;
         }
 
-        public void Start()
+        public void Start(SpotifyMonitor sm)
         {
             spotifyVolume = GetCurrentVolume(); //Get initial spotify-volume
-            SpotifyMonitor.GetMonitorInstance(sc).Subscribe(this);
+            sm.Subscribe(this);
         }
 
         private void UpdateVolume()

--- a/SpotifyVolumeExtension/SpotifyVolumeController.cs
+++ b/SpotifyVolumeExtension/SpotifyVolumeController.cs
@@ -8,8 +8,8 @@ namespace SpotifyVolumeExtension
     {
         private MediaKeyListener mkl;
         private SpotifyClient sc;
-        private volatile int lastVolume;
-        private volatile int spotifyVolume;
+        private int lastVolume;
+        private int spotifyVolume;
         private DateTime lastVolumePress;
         private Timer blockTimer;
         private bool blockUpdates;

--- a/SpotifyVolumeExtension/SpotifyVolumeController.cs
+++ b/SpotifyVolumeExtension/SpotifyVolumeController.cs
@@ -29,7 +29,6 @@ namespace SpotifyVolumeExtension
 
         public void Start(SpotifyMonitor sm)
         {
-            spotifyVolume = GetCurrentVolume(); //Get initial spotify-volume
             sm.SpotifyStatusChanged += ToggleVolumeController;
         }
 
@@ -37,8 +36,8 @@ namespace SpotifyVolumeExtension
         {
             if (status)
             {
+                spotifyVolume = GetCurrentVolume(); //Get initial spotify-volume
                 mkl.Start();
-                spotifyVolume = GetCurrentVolume();
             }
             else
             {

--- a/SpotifyVolumeExtension/SpotifyVolumeExtension.csproj
+++ b/SpotifyVolumeExtension/SpotifyVolumeExtension.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SpotifyClient.cs" />
+    <Compile Include="SpotifyMonitor.cs" />
     <Compile Include="SpotifyVolumeController.cs" />
     <Compile Include="MediaKeyListener.cs" />
     <Compile Include="VolumeGuard.cs" />

--- a/SpotifyVolumeExtension/VolumeGuard.cs
+++ b/SpotifyVolumeExtension/VolumeGuard.cs
@@ -4,18 +4,28 @@ using System;
 
 namespace SpotifyVolumeExtension
 {
-    public class VolumeGuard : IObserver<DeviceVolumeChangedArgs>
+    public class VolumeGuard : IObserver<DeviceVolumeChangedArgs>, IObserver<SpotifyStatusChanged>
     {
         private int originalVolume = 0;
         private object m = new object();
+        SpotifyClient sc;
+        CoreAudioDevice audioDevice;
+        IDisposable subscriber;
+
+        public VolumeGuard(SpotifyClient sc)
+        {
+            this.sc = sc;
+        }
 
         public void Start()
         {
-            CoreAudioDevice audioDevice = new CoreAudioController().DefaultPlaybackDevice;
+            SpotifyMonitor.GetMonitorInstance(sc).Subscribe(this);
+        }
+
+        private void SetVolumeBaseline()
+        {
+            audioDevice = new CoreAudioController().DefaultPlaybackDevice;
             originalVolume = (int)audioDevice.Volume;
-            
-            audioDevice.VolumeChanged.Subscribe(this);
-            Console.WriteLine("[VolumeGuard] Started.");
         }
 
         public void OnCompleted()
@@ -34,6 +44,21 @@ namespace SpotifyVolumeExtension
             {
                 value.Device.Volume = originalVolume;
             }
+        }
+
+        public void OnNext(SpotifyStatusChanged value)
+        {
+            if (value.Status && subscriber == null)
+            {
+                SetVolumeBaseline();
+                subscriber = audioDevice.VolumeChanged.Subscribe(this);
+            }
+            else
+            {
+                subscriber.Dispose();
+                subscriber = null;
+            }
+            Console.WriteLine("[VolumeGuard] " + (value.Status ? "Started." : "Stopped."));
         }
     }
 }

--- a/SpotifyVolumeExtension/VolumeGuard.cs
+++ b/SpotifyVolumeExtension/VolumeGuard.cs
@@ -10,7 +10,6 @@ namespace SpotifyVolumeExtension
         private object m = new object();
         CoreAudioDevice audioDevice;
         IDisposable subscriber;
-        
 
         public void Start(SpotifyMonitor sm)
         {

--- a/SpotifyVolumeExtension/VolumeGuard.cs
+++ b/SpotifyVolumeExtension/VolumeGuard.cs
@@ -8,18 +8,13 @@ namespace SpotifyVolumeExtension
     {
         private int originalVolume = 0;
         private object m = new object();
-        SpotifyClient sc;
         CoreAudioDevice audioDevice;
         IDisposable subscriber;
+        
 
-        public VolumeGuard(SpotifyClient sc)
+        public void Start(SpotifyMonitor sm)
         {
-            this.sc = sc;
-        }
-
-        public void Start()
-        {
-            SpotifyMonitor.GetMonitorInstance(sc).Subscribe(this);
+            sm.Subscribe(this);
         }
 
         private void SetVolumeBaseline()


### PR DESCRIPTION
* Added semaphore in SpotifyVolumeController to make volume-changes more consistent, previously other threads could read the volume-values while they were in the process of being changed, causing unwanted behaviour. 
* SpotifyClient now waits longer before checking again if it didn't detect any music playing.
* SpotifyMonitor added. - This class checks if Spotify is running & playing music periodically and updates SpotifyVolumeController and VolumeGuard if the status changed via an event. This will allow the user to change the system-volume whenever Spotify isn't playing music.
* Checking if music is playing instead of checking for an active device, this makes sure that music is actually playing. A device can be active and not be playing music, this fixes that.
* Spinning up a separate thread for the MediaKeyListener since the `Open.WinKeyboardHook` library refuses to run properly without `Application.Run()` present.
* Other general code improvements.

